### PR TITLE
Windows/VSC dev, dependencies, and lint configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-db
-vendor
+db/
+vendor/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,23 @@
+AllCops:
+  TargetRubyVersion: 2.7
+  Exclude:
+    - "**\\lib\\ruby\\**\\*"
+  NewCops: enable
+Layout/LineLength:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Style/GlobalVars:
+  Enabled: false
+Style/MultilineTernaryOperator:
+  Enabled: false
+Style/RedundantReturn:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/Documentation:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,15 +9,5 @@ Metrics/BlockLength:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
-Metrics/AbcSize:
-  Enabled: true
 Style/GlobalVars:
   Enabled: false
-Style/MultilineTernaryOperator:
-  Enabled: true
-Style/RedundantReturn:
-  Enabled: true
-Style/FrozenStringLiteralComment:
-  Enabled: true
-Style/Documentation:
-  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   Exclude:
     - "**\\lib\\ruby\\**\\*"
   NewCops: enable
@@ -10,14 +10,14 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Enabled: false
 Metrics/AbcSize:
-  Enabled: false
+  Enabled: true
 Style/GlobalVars:
   Enabled: false
 Style/MultilineTernaryOperator:
-  Enabled: false
+  Enabled: true
 Style/RedundantReturn:
-  Enabled: false
+  Enabled: true
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
 Style/Documentation:
-  Enabled: false
+  Enabled: true

--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,20 @@
+---
+include:
+  - "**/*.rb"
+exclude:
+  - spec/**/*
+  - test/**/*
+  - vendor/**/*
+  - ".bundle/**/*"
+  - "**/lib/ruby/**/*"
+require: []
+domains: []
+reporters:
+  - rubocop
+  - require_not_found
+formatter:
+  rubocop:
+    extra_args: ["--force-exclusion"]
+require_paths: []
+plugins: []
+max_files: 5000

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
-	"recommendations": [
-		"rebornix.ruby",
+    "recommendations": [
+        "rebornix.ruby",
         "wingrunr21.vscode-ruby",
         "castwide.solargraph"
-	]
+    ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	"recommendations": [
+		"rebornix.ruby",
+        "wingrunr21.vscode-ruby",
+        "castwide.solargraph"
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Debug Launch configuration.
+    // Make sure you have the environment variable "BUNDLE_PATH" pointing to your ruby/bin/bundle(.bat) location.
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Local",
+            "type": "Ruby",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "debuggerPort": "1234",
+            "program": "${workspaceRoot}/main.rb",
+            "showDebuggerOutput": true,
+            "useBundler": true,
+            "pathToBundler": "${env:BUNDLE_PATH}",
+            "pathToRDebugIDE": "${workspaceRoot}/bin/rdebug-ide",
+            "env": {
+                "PATH": "${env:PATH}",
+                "DISCORDRB_NONACL": "Ignore libsodium check"
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "ruby.useBundler": true,
+    "ruby.format": false,
+    "solargraph.useBundler": true,
+    "solargraph.formatting": true,
+    "solargraph.autoformat": true,
+    "solargraph.diagnostics": true
+}

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 gem 'activesupport'
-gem 'discordrb', git: 'https://github.com/shardlab/discordrb', branch: 'main', tag: 'v3.4.2'
+gem 'discordrb'
 gem 'httparty'
 gem 'json'
 gem 'slop'

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source 'https://rubygems.org'
 gem 'activesupport'
-gem 'debase'
 gem 'discordrb', git: 'https://github.com/shardlab/discordrb', branch: 'main', tag: 'v3.4.2'
 gem 'httparty'
 gem 'json'
-gem 'ruby-debug-ide'
 gem 'slop'
+
+gem 'debase', group: :development
+gem 'ruby-debug-ide', group: :development
 gem 'solargraph', group: :development

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
-gem 'discordrb'
-gem 'slop'
-gem 'json'
-gem 'httparty'
 gem 'activesupport'
+gem 'debase'
+gem 'discordrb', git: 'https://github.com/shardlab/discordrb', branch: 'main', tag: 'v3.4.2'
+gem 'httparty'
+gem 'json'
+gem 'ruby-debug-ide'
+gem 'slop'
 gem 'solargraph', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,22 @@
+GIT
+  remote: https://github.com/shardlab/discordrb
+  revision: 75d3e6a8fd2cda78a1e3c8e4585b33372b5800e4
+  branch: main
+  tag: v3.4.2
+  specs:
+    discordrb (3.4.2)
+      discordrb-webhooks (~> 3.4.2)
+      ffi (>= 1.9.24)
+      opus-ruby
+      rest-client (>= 2.0.0)
+      websocket-client-simple (>= 0.3.0)
+    discordrb-webhooks (3.4.2)
+      rest-client (>= 2.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.2.1)
+    activesupport (6.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -11,19 +26,15 @@ GEM
     backport (1.1.2)
     benchmark (0.1.1)
     concurrent-ruby (1.1.8)
-    discordrb (3.4.0)
-      discordrb-webhooks (~> 3.3.0)
-      ffi (>= 1.9.24)
-      opus-ruby
-      rest-client (>= 2.0.0)
-      websocket-client-simple (>= 0.3.0)
-    discordrb-webhooks (3.3.0)
-      rest-client (>= 2.1.0.rc1)
+    debase (0.2.4.1)
+      debase-ruby_core_source (>= 0.10.2)
+    debase-ruby_core_source (0.10.12)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     e2mmap (0.1.0)
     event_emitter (0.2.6)
-    ffi (1.14.2)
+    ffi (1.15.0)
+    ffi (1.15.0-x64-mingw32)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -40,11 +51,13 @@ GEM
       kramdown (~> 2.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.1104)
-    minitest (5.14.3)
+    mime-types-data (3.2021.0225)
+    minitest (5.14.4)
     multi_xml (0.6.0)
     netrc (0.11.0)
-    nokogiri (1.11.1-x86_64-linux)
+    nokogiri (1.11.2-x64-mingw32)
+      racc (~> 1.4)
+    nokogiri (1.11.2-x86_64-linux)
       racc (~> 1.4)
     opus-ruby (1.0.1)
       ffi
@@ -53,8 +66,15 @@ GEM
       ast (~> 2.4.1)
     racc (1.5.2)
     rainbow (3.0.0)
-    regexp_parser (2.0.3)
+    rake (13.0.3)
+    regexp_parser (2.1.1)
     rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rest-client (2.1.0-x64-mingw32)
+      ffi (~> 1.9)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -62,7 +82,7 @@ GEM
     reverse_markdown (2.0.0)
       nokogiri
     rexml (3.2.4)
-    rubocop (1.9.1)
+    rubocop (1.11.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -73,9 +93,11 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
+    ruby-debug-ide (0.7.2)
+      rake (>= 0.8.1)
     ruby-progressbar (1.11.0)
     slop (4.8.2)
-    solargraph (0.40.3)
+    solargraph (0.40.4)
       backport (~> 1.1)
       benchmark
       bundler (>= 1.17.2)
@@ -96,6 +118,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
+    unf_ext (0.0.7.7-x64-mingw32)
     unicode-display_width (2.0.0)
     websocket (1.2.9)
     websocket-client-simple (0.3.0)
@@ -105,13 +128,16 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  x64-mingw32
   x86_64-linux
 
 DEPENDENCIES
   activesupport
-  discordrb
+  debase
+  discordrb!
   httparty
   json
+  ruby-debug-ide
   slop
   solargraph
 


### PR DESCRIPTION
* Bump all dependencies
* Generate .lock file for Windows development
* Use GitHub for discordrb gem
+ Add debase and ruby-debug-ide for debugging
+ VSCode workspace configs
+ Lint configs


I've made the lint configs less annoying and have picked 2.7 for the target version. Do you want to commit to using 2.5?